### PR TITLE
Add retries, force cast of partition to string and prefect_extracted_at

### DIFF
--- a/iplanrio/pipelines_templates/dump_db/tasks.py
+++ b/iplanrio/pipelines_templates/dump_db/tasks.py
@@ -26,7 +26,7 @@ def parse_comma_separated_string_to_list_task(text: Optional[str]) -> List[str]:
     return parse_comma_separated_string_to_list(text)
 
 
-@task
+@task(retries=3)
 def dump_upload_batch_task(
     database_type: str,
     hostname: str,

--- a/iplanrio/pipelines_templates/dump_db/utils.py
+++ b/iplanrio/pipelines_templates/dump_db/utils.py
@@ -32,6 +32,7 @@ from iplanrio.pipelines_utils.io import (
 )
 from iplanrio.pipelines_utils.logging import log, log_mod
 from iplanrio.pipelines_utils.pandas import (
+    add_ingestion_timestamp,
     batch_to_dataframe,
     build_query_new_columns,
     clean_dataframe,
@@ -41,7 +42,6 @@ from iplanrio.pipelines_utils.pandas import (
     parse_date_columns,
     remove_columns_accents,
     to_partitions,
-    add_ingestion_timestamp,
 )
 
 

--- a/iplanrio/pipelines_templates/dump_db/utils.py
+++ b/iplanrio/pipelines_templates/dump_db/utils.py
@@ -41,6 +41,7 @@ from iplanrio.pipelines_utils.pandas import (
     parse_date_columns,
     remove_columns_accents,
     to_partitions,
+    add_ingestion_timestamp,
 )
 
 
@@ -212,6 +213,7 @@ def _process_single_query(
         dataframe.columns = remove_columns_accents(dataframe)
         new_columns_dict = dict(zip(old_columns, dataframe.columns.tolist()))
         dataframe = clean_dataframe(dataframe)
+        dataframe = add_ingestion_timestamp(dataframe)
         saved_files = []
         if partition_column:
             dataframe, date_partition_columns = parse_date_columns(
@@ -911,7 +913,14 @@ def build_chunk_query(
         where {partition_column} >= TO_DATE('{current_start.strftime(date_format)}', '{oracle_date_format}')
             and {partition_column} <= TO_DATE('{current_end.strftime(date_format)}', '{oracle_date_format}')
         """
-    elif database_type in ["mysql", "postgres", "sql_server"]:
+    elif database_type in ["sql_server"]:
+        query = f"""
+        with {aux_name} as ({query})
+        select * from {aux_name}
+        where CONVERT(DATE, CAST({partition_column} AS VARCHAR)) >= '{current_start.strftime(date_format)}'
+            and CONVERT(DATE, {partition_column}) <= '{current_end .strftime(date_format)}'
+        """
+    elif database_type in ["mysql", "postgres"]:
         query = f"""
         with {aux_name} as ({query})
         select * from {aux_name}

--- a/iplanrio/pipelines_utils/pandas.py
+++ b/iplanrio/pipelines_utils/pandas.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
+from datetime import datetime
 from os import walk
 from os.path import join
 from pathlib import Path
@@ -125,6 +126,26 @@ def final_column_treatment(column: str) -> str:
     except ValueError:
         non_alpha_removed = re.sub(r"[\W]+", "", column)
         return non_alpha_removed
+
+
+def add_ingestion_timestamp(dataframe: pd.DataFrame) -> pd.DataFrame:
+    """
+    Adds a timestamp column indicating when the data was extracted.
+    
+    Args:
+        dataframe: The DataFrame to add the timestamp to
+        
+    Returns:
+        DataFrame with the _prefect_extracted_at column added
+    """
+    ingestion_col = "_prefect_extracted_at"
+    
+    if ingestion_col in dataframe.columns:
+        raise ValueError(f"Column {ingestion_col} already exists, please review your model.")
+    
+    dataframe[ingestion_col] = datetime.now()
+    
+    return dataframe
 
 
 def parse_date_columns(

--- a/iplanrio/pipelines_utils/pandas.py
+++ b/iplanrio/pipelines_utils/pandas.py
@@ -131,20 +131,22 @@ def final_column_treatment(column: str) -> str:
 def add_ingestion_timestamp(dataframe: pd.DataFrame) -> pd.DataFrame:
     """
     Adds a timestamp column indicating when the data was extracted.
-    
+
     Args:
         dataframe: The DataFrame to add the timestamp to
-        
+
     Returns:
         DataFrame with the _prefect_extracted_at column added
     """
     ingestion_col = "_prefect_extracted_at"
-    
+
     if ingestion_col in dataframe.columns:
-        raise ValueError(f"Column {ingestion_col} already exists, please review your model.")
-    
+        raise ValueError(
+            f"Column {ingestion_col} already exists, please review your model."
+        )
+
     dataframe[ingestion_col] = datetime.now()
-    
+
     return dataframe
 
 


### PR DESCRIPTION
This pull request introduces improvements to the data extraction pipeline, focusing on enhanced data traceability and more robust database query handling. The most significant changes include adding an ingestion timestamp to extracted data, updating database partitioning logic for SQL Server, and improving task reliability.

**Data traceability improvements:**

* Added a new function `add_ingestion_timestamp` in `iplanrio/pipelines_utils/pandas.py` to append a `_prefect_extracted_at` column with the current timestamp to each extracted DataFrame, ensuring every data batch records its extraction time.
* Integrated `add_ingestion_timestamp` into the data processing workflow by invoking it within `_process_single_query` in `iplanrio/pipelines_templates/dump_db/utils.py`, so all processed dataframes include the ingestion timestamp.
* Imported `add_ingestion_timestamp` in `iplanrio/pipelines_templates/dump_db/utils.py` to make it available for use in the pipeline.

**Database query handling improvements:**

* Modified the `build_chunk_query` function in `iplanrio/pipelines_templates/dump_db/utils.py` to handle SQL Server partitioning logic separately from MySQL and Postgres, using `CONVERT(DATE, ...)` for more accurate date filtering.

**Task reliability:**

* Updated the `dump_upload_batch_task` in `iplanrio/pipelines_templates/dump_db/tasks.py` to include automatic retries (up to 3 times), improving robustness against transient failures.